### PR TITLE
Parameterise url

### DIFF
--- a/good_morning/good_morning.py
+++ b/good_morning/good_morning.py
@@ -40,7 +40,7 @@ class KeyRatiosDownloader(object):
         """
         self._table_prefix = table_prefix
 
-    def download(self, ticker, conn = None, region='GBR', culture='en_US', currency='USD'):
+    def download(self, ticker, conn = None, region = 'GBR', culture = 'en_US', currency = 'USD'):
         u"""Downloads and returns key ratios for the given Morningstar ticker.
 
         Downloads and returns an array of pandas.DataFrames containing the key

--- a/good_morning/good_morning.py
+++ b/good_morning/good_morning.py
@@ -40,7 +40,7 @@ class KeyRatiosDownloader(object):
         """
         self._table_prefix = table_prefix
 
-    def download(self, ticker, conn = None):
+    def download(self, ticker, conn = None, region='GBR', culture='en_US', currency='USD'):
         u"""Downloads and returns key ratios for the given Morningstar ticker.
 
         Downloads and returns an array of pandas.DataFrames containing the key
@@ -53,8 +53,8 @@ class KeyRatiosDownloader(object):
         :return: List of pandas.DataFrames containing the key ratios.
         """
         url = (r'http://financials.morningstar.com/ajax/exportKR2CSV.html?' +
-               r'&callback=?&t={0}&region=usa&culture=en-US&cur=USD'.format(
-                   ticker))
+               r'&callback=?&t={t}&region={reg}&culture={cult}&cur={cur}'.format(
+                   t=ticker, reg=region, cult=culture, cur=currency))
         with urllib.request.urlopen(url) as response:
             tables = self._parse_tables(response)
             response_structure = [

--- a/good_morning/good_morning.py
+++ b/good_morning/good_morning.py
@@ -50,6 +50,9 @@ class KeyRatiosDownloader(object):
 
         :param ticker: Morningstar ticker.
         :param conn: MySQL connection.
+        :param region: Sets the region.
+        :param culture: Sets culture.
+        :param currency: Sets currency.
         :return: List of pandas.DataFrames containing the key ratios.
         """
         url = (r'http://financials.morningstar.com/ajax/exportKR2CSV.html?' +


### PR DESCRIPTION
When setting following parameters "region=usa&culture=en-US&cur=USD", the data I received was strangely in EUR rather than USD. To get results in USD I had to use "region=GBR&culture=en_US" (not using the cur parameter at all). Not sure whether this is location dependent but parameterising should alleviate the issue.